### PR TITLE
Escape wildcard subdomain

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -143,7 +143,7 @@ id: 2
 name: vapor-laravel-app
 environments:
     production:
-        domain: *.example.com
+        domain: \*.example.com
         build:
             - 'composer install --no-dev --classmap-authoritative'
 ```

--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -143,7 +143,7 @@ id: 2
 name: vapor-laravel-app
 environments:
     production:
-        domain: \*.example.com
+        domain: '*.example.com'
         build:
             - 'composer install --no-dev --classmap-authoritative'
 ```


### PR DESCRIPTION
When following the docs to add a wildcard subdomain, I'm receiving this error:

![Screen Shot 2019-09-13 at 1 02 43 PM](https://user-images.githubusercontent.com/791222/64888401-28059080-d628-11e9-8dda-a88728c415d9.png)

It works fine if I escape the `*` with a `\`: `domain: \*.ohseemedia.com`