### PR TITLE
Set code syntax

### DIFF
--- a/1.0/resources/storage.md
+++ b/1.0/resources/storage.md
@@ -43,20 +43,24 @@ window.Vapor = require('laravel-vapor');
 
 Before initiating an upload directly to S3, Vapor's internal signed storage URL generator will perform an authorization check against the currently authenticated user. If you do not already have one, you should create a `UserPolicy` for your application using the following command:
 
-    php artisan make:policy UserPolicy --model=User
+```bash
+php artisan make:policy UserPolicy --model=User
+```
 
 Next, you should add an `uploadFiles` method to this policy. This method should return `true` if the given authenticated user is allowed to upload files. Otherwise, you should return `false`:
 
-    /**
-     * Determine whether the user can upload files.
-     *
-     * @param  \App\User  $user
-     * @return mixed
-     */
-    public function uploadFiles(User $user)
-    {
-        return true;
-    }
+```php
+/**
+ * Determine whether the user can upload files.
+ *
+ * @param  \App\User  $user
+ * @return mixed
+ */
+public function uploadFiles(User $user)
+{
+    return true;
+}
+```
 
 ### Streaming Files To S3
 


### PR DESCRIPTION
This fixes the code syntax that is currently showing as dark gray on black

Before.

<img width="834" alt="image" src="https://user-images.githubusercontent.com/228899/65391321-c676ad80-dd1c-11e9-9954-7627cccc0eff.png">


After.

<img width="806" alt="image" src="https://user-images.githubusercontent.com/228899/65400304-43824100-dd76-11e9-98db-68152a3342fa.png">
