### PR TITLE
Fix incorrect queue timeout setting

### DIFF
--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,14 +35,14 @@ environments:
 
 ## Queue Visibility Timeout
 
-By default, if your queued job is not deleted or released within one minute of beginning to process, SQS will retry the job. To configure this "visibility timeout", you may define the `queue-timeout` option in the environment's `vapor.yml` configuration. For example, we may set this timeout to five minutes:
+By default, if your queued job is not deleted or released within one minute of beginning to process, SQS will retry the job. To configure this "visibility timeout", you may define the `cli-timeout` option in the environment's `vapor.yml` configuration. For example, we may set this timeout to five minutes:
 
 ```yaml
 id: 2
 name: vapor-laravel-app
 environments:
     production:
-        queue-timeout: 300
+        cli-timeout: 300
         build:
             - 'composer install --no-dev --classmap-authoritative'
 ```


### PR DESCRIPTION
It appears that the `queue-timeout` setting is mislabeled, and should actually be `cli-timeout`.  After setting a `queue-timeout` option of 300 seconds and deploying, we noticed that our CLI Lambda timeout was still 60 seconds, and our Default Visibility Timeout for our SQS instance was still 70 seconds.

After changing `queue-timeout` to `cli-timeout` as a random guess and deploying, our CLI Lambda timeout indeed updated to 300 seconds, and our SQS Default Visibility Timeout increased to the expected 310 seconds.