### PR TITLE
Update Composer command causing issues with separate vendor directory

### DIFF
--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -27,7 +27,7 @@ environments:
         database: vapor-app
         cache: vapor-cache
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
             - 'php artisan event:cache'
         deploy:
             - 'php artisan migrate --force'
@@ -46,7 +46,7 @@ environments:
         database: vapor-app
         cache: vapor-cache
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
             - 'php artisan event:cache'
         deploy:
             - 'php artisan migrate --force'

--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -24,10 +24,10 @@ name: vapor-laravel-app
 environments:
     production:
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
     my-environment:
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 
 ## Environment Variables
@@ -122,7 +122,7 @@ environments:
     production:
         domain: example.com
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 
 During deployment, Vapor will configure the environment to handle requests on this domain. After the deployment is completed, Vapor will provide you with CNAME records for the domain. These records will point the domain to your Lambda application.
@@ -145,7 +145,7 @@ environments:
     production:
         domain: '*.example.com'
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 
 ## Maintenance Mode
@@ -194,7 +194,7 @@ environments:
     production:
         warm: 10
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 
 ## Concurrency
@@ -210,7 +210,7 @@ environments:
     production:
         concurrency: 50
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 
 ## Timeout
@@ -224,7 +224,7 @@ environments:
     production:
         timeout: 20
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 
 ## Metrics

--- a/1.0/resources/caches.md
+++ b/1.0/resources/caches.md
@@ -32,7 +32,7 @@ environments:
     production:
         cache: my-application-cache
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
         deploy:
             - 'php artisan migrate --force'
 ```

--- a/1.0/resources/databases.md
+++ b/1.0/resources/databases.md
@@ -61,7 +61,7 @@ environments:
     production:
         database: my-application-db
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
         deploy:
             - 'php artisan migrate --force'
 ```
@@ -102,7 +102,7 @@ environments:
         database: my-application-db
         database-user: user-2
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
         deploy:
             - 'php artisan migrate --force'
 ```

--- a/1.0/resources/networks.md
+++ b/1.0/resources/networks.md
@@ -62,7 +62,7 @@ environments:
     production:
         balancer: my-balancer
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
         deploy:
             - 'php artisan migrate --force'
 ```

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -30,7 +30,7 @@ environments:
     production:
         cli-concurrency: 50
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 
 ## Queue Visibility Timeout
@@ -44,6 +44,6 @@ environments:
     production:
         cli-timeout: 300
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
 ```
 

--- a/1.0/resources/storage.md
+++ b/1.0/resources/storage.md
@@ -18,7 +18,7 @@ environments:
         storage: my-bucket-name
         memory: 1024
         build:
-            - 'composer install --no-dev --classmap-authoritative'
+            - 'composer install --no-dev'
         deploy:
             - 'php artisan migrate --force'
 ```


### PR DESCRIPTION
In reference to: https://github.com/laravel/vapor-cli/pull/23

This PR removes references to the classmap-authoritative Composer argument that causes issues when using the separate-vendor option.