### PR TITLE
Concurrency text adjustments

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -199,7 +199,7 @@ environments:
 
 ## Concurrency
 
-By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 concurrent requests executing at the same time at any given moment. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration.
+By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 requests executing at the same time at any given moment. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration. Additionally, if you need more than 1,000 concurrent requests, you can submit a limit increase request in the AWS Support Center console.
 
 While maximum performance is certainly appealing, in some situations it may make sense to set this value to the maximum concurrency you reasonably expect for your particular application. Otherwise, a DDoS attack against your application could result in larger than expected AWS costs:
 


### PR DESCRIPTION
- Removed "concurrent" as "same time" means concurrent (what a nit pick)
- Added note about increasing concurrency. Unlikely for it to be common but useful for users to know it's possible