### PR TITLE
Add cli-timeout to docs

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -197,6 +197,18 @@ vapor command production
 vapor command production --command="php artisan inspire"
 ```
 
+By default, your command will timeout at 1 minute. You can configure the timeout of your commands using the `cli-timeout` option:
+
+```yaml
+id: 2
+name: vapor-laravel-app
+environments:
+    production:
+        cli-timeout: 20
+        build:
+            - 'composer install --no-dev'
+```
+
 ## Concurrency
 
 By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 requests executing at the same time at any given moment. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration. Additionally, if you need more than 1,000 concurrent requests, you can submit a limit increase request in the AWS Support Center console.

--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -197,7 +197,7 @@ vapor command production
 vapor command production --command="php artisan inspire"
 ```
 
-By default, your command will timeout at 1 minute. You can configure the timeout of your commands using the `cli-timeout` option:
+By default, your command will timeout after one minute. You can configure the timeout of your CLI commands using the `cli-timeout` option within your `vapor.yml` file:
 
 ```yaml
 id: 2


### PR DESCRIPTION
Basic note on cli-timeout. Appreciate you can also add cli-concurrency but I think it's a confusion & distraction to add that to docs, since commands will be scheduled by admin users / kernel, so they wouldn't care to limit the concurrency. Unless you can think of a case that cli-concurrency would be useful?