### PR TITLE
Add note for DNS records without name

### DIFF
--- a/1.0/domains/dns.md
+++ b/1.0/domains/dns.md
@@ -27,6 +27,8 @@ Once a zone has been created for a domain, you can add, update, or remove DNS re
 ```bash
 vapor record example.com A www 192.168.1.1
 
+vapor record example.com A @ 192.168.1.1
+
 vapor record example.com CNAME foo another-example.com
 
 vapor record example.com MX foo "10 example.com,20 example2.com"
@@ -35,11 +37,6 @@ vapor record example.com MX foo "10 example.com,20 example2.com"
 :::tip Record Upserts
 
 The `record` command functions as an "UPSERT" operation. If an existing record exists with the given type and name, its value will be updated to the given value. If no record exists with the given type or name, the record will be created.
-:::
-
-:::tip Records without name
-
-To create records with no name, please use the `@` sign as value for the name field. This may be applicable for eg. MX records or your main domain record.
 :::
 
 ### Deleting Records

--- a/1.0/domains/dns.md
+++ b/1.0/domains/dns.md
@@ -37,6 +37,11 @@ vapor record example.com MX foo "10 example.com,20 example2.com"
 The `record` command functions as an "UPSERT" operation. If an existing record exists with the given type and name, its value will be updated to the given value. If no record exists with the given type or name, the record will be created.
 :::
 
+:::tip Records without name
+
+To create records with no name, please use the `@` sign as value for the name field. This may be applicable for eg. MX records or your main domain record.
+:::
+
 ### Deleting Records
 
 To delete a record via the Vapor CLI, you may use the `record:delete` command:


### PR DESCRIPTION
I didn't know that I could create DNS records without a name by supplying the `@` sign as value for the name input field. Thanks to @themsaid for the information: https://twitter.com/themsaid/status/1247930207366938627