### PR TITLE
Adds 'Public Uploads' notes

### DIFF
--- a/1.0/resources/storage.md
+++ b/1.0/resources/storage.md
@@ -86,6 +86,21 @@ Vapor.store(this.$refs.file.files[0], {
 
 All uploaded files will be placed in a `tmp` directory within the bucket. **This directory is automatically configured to purge any files older than 24 hours.** This feature serves to conveniently clean up file uploads that are initiated but not completed, such as a user that begins updating their profile photo but does not save the change.
 
+#### Public Uploads
+
+Should you wish for the streamed file to be public, simply add `visibility: 'public-read'` to the object passed to the `Vapor.store` method like so:
+
+```js
+Vapor.store(this.$refs.file.files[0], {
+    progress: progress => {
+        this.uploadProgress = Math.round(progress * 100);
+    },
+    visibility: 'public-read'
+})
+```
+
+The public visibility status will be retained following its copy to permanent storage.
+
 ### Acknowledge File Uploads & Permanent Storage
 
 All uploaded files will be stored using a UUID as their filename. The `response` provided to the `store` method's `then` callback will contain the UUID of the file, the file's full S3 key, and the file's bucket. You may then POST this information to your application's backend to permanently store the file by moving it out of the bucket's `tmp` directory. In addition, you may wish to store additional information about the file, such as its original name and content type, in your application's database:


### PR DESCRIPTION
Highlights the possibility of setting visibility to public-read when streaming uploads to S3 via `Vapor.store`