### PR TITLE
Add php extension docs

### DIFF
--- a/.vuepress/1.0.js
+++ b/.vuepress/1.0.js
@@ -24,6 +24,7 @@ module.exports = [
       'databases',
       'caches',
       'logs',
+      'phpExtensions'
     ]),
   },
   {

--- a/1.0/resources/phpExtensions.md
+++ b/1.0/resources/phpExtensions.md
@@ -4,11 +4,13 @@
 
 ## Introduction
 
-When your application requires additional php extensions, which are not part of the [Server requirements](https://laravel.com/docs/#server-requirements) by laravel, you are required to add them to your build layers in vapor. Please refer to [brefphp/extra-php-extensions](https://github.com/brefphp/extra-php-extensions) for a list of [available layers](https://github.com/brefphp/extra-php-extensions#available-layers).
+When your application requires additional php extensions, which are not part of the [Server requirements](https://laravel.com/docs/#server-requirements) by laravel, you are required to add them as additional AWS Lambda Layers in Vapor.
 
 ## Adding Extensions
 
-To add an extension to your project, you need to create a `php.ini` file in the root directory which lists the additional extensions to load. Lets use `Imagick` as an example:
+To add an extension to your project, you need to create a `php.ini` file in the root directory which lists the additional extensions to load. Please refer to [brefphp/extra-php-extensions](https://github.com/brefphp/extra-php-extensions) for a list of [available layers](https://github.com/brefphp/extra-php-extensions#available-layers).
+
+Lets use `Imagick` as an example:
 
 ```sh
 extension=/opt/bref-extra/imagick.so

--- a/1.0/resources/phpExtensions.md
+++ b/1.0/resources/phpExtensions.md
@@ -1,0 +1,27 @@
+# PHP Extensions
+
+[[toc]]
+
+## Introduction
+
+When your application requires additional php extensions, which are not part of the [Server requirements](https://laravel.com/docs/#server-requirements) by laravel, you are required to add them to your build layers in vapor. Please refer to [brefphp/extra-php-extensions](https://github.com/brefphp/extra-php-extensions) for a list of [available layers](https://github.com/brefphp/extra-php-extensions#available-layers).
+
+## Adding Extensions
+
+To add an extension to your project, you need to create a `php.ini` file in the root directory which lists the additional extensions to load. Lets use `Imagick` as an example:
+
+```sh
+extension=/opt/bref-extra/imagick.so
+```
+
+Additionally to the `php.ini` file, you also need to register a new layer in your `vapor.yml` file. Please note that AWS Lambda has a limit of 5 layers, if you require more than that, you'll need to compose your own layer as described [here](https://github.com/brefphp/extra-php-extensions#creating-a-new-layer).
+
+```yaml
+environments:
+    staging:
+        layers:
+          - vapor:php-7.4
+          - vapor:php-7.4:imagick
+```
+
+Once added, redeploy your application in order to utilize the new added extension.


### PR DESCRIPTION
# Why
Based on @themsaid's [blog post](https://blog.laravel.com/vapor-adding-imagick-as-a-separate-lambda-layer) and comment on a [github issue](https://github.com/laravel/vapor-php-build/issues/3#issuecomment-633825962), I've added a section `PHP Extensions`.

# Changes
This adds a new page in resources, shortly describing how to add an extension by the example of imagick. I assumed any of the `bref-extra` extensions can be used as well as contributed layers to their repo.

# Open Questions
Guess it might need more information and I might not know everything involved in the AWS Lambda Layers such as where `vapor:php-7.4:imagick` comes from and how custom layers can make it in if any.

- Can other layers be added? If so how?
- How many layers does Vapor already use, given that a 5 layer limit per lambda exists?


