### PR TITLE
Queue memory reservation example

### DIFF
--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -75,6 +75,21 @@ environments:
             - 'composer install --no-dev'
 ```
 
+## Queue Memory
+
+By default, 512 mb will be reserved on AWS Lambda for your queue. To override this, use ```queue-memory```.
+
+```yaml
+id: 2
+name: vapor-laravel-app
+environments:
+    production:
+        queue-memory: 1024
+        build:
+            - 'composer install --no-dev'
+```
+
+
 ## Monitoring Jobs
 
 If you have installed the [Vapor UI dashboard package](./../introduction.html#installing-the-vapor-ui-dashboard), you may access the `/vapor-ui/jobs/metrics` URI to monitor queue jobs.


### PR DESCRIPTION
There is a post about queue memory but its not in the docs: https://blog.laravel.com/vapor-using-a-separate-lambda-function-for-queues