### PR TITLE
Recommends docker images instead of "separate-vendor" flag

### DIFF
--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -14,6 +14,13 @@ To initiate a deployment, execute the `deploy` CLI command from the root of your
 vapor deploy production
 ```
 
+:::warning Application Size
+
+AWS Lambda has strict limitations on the size of applications running within the environment. Typically, the size of your application should not be a problem. However, you may receive an error indicating that your project is too large.
+
+To mitigate this, Vapor offers [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#building-custom-docker-images). Which allows developers to package and deploy applications as Docker container images of up to 10GB.
+:::
+
 ## Build Hooks
 
 You may define build hooks for an environment using the `build` key within your `vapor.yml` file. These commands are executed on the local machine that the deployment is running on and may be used to prepare your application for deployment. During deployment, your application is built within a temporary `.vapor` directory that is created by the CLI and all of your `build` commands will run within that temporary directory:

--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -16,9 +16,7 @@ vapor deploy production
 
 :::warning Application Size
 
-AWS Lambda has strict limitations on the size of applications running within the environment. Typically, the size of your application should not be a problem. However, you may receive an error indicating that your project is too large.
-
-To mitigate this, Vapor offers [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#building-custom-docker-images). Which allows developers to package and deploy applications as Docker container images of up to 10GB.
+AWS Lambda has strict limitations on the size of applications running within the environment. If your application exceeds this limit, you may take advantage of Vapor's [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#building-custom-docker-images). Docker based deployments allow you to package and deploy applications up to 10GB in size.
 :::
 
 ## Build Hooks

--- a/1.0/projects/the-basics.md
+++ b/1.0/projects/the-basics.md
@@ -27,20 +27,6 @@ vapor team:switch
 
 Within Vapor's "Project Settings" screen, you may provide the GitHub repository information for a project. Providing this information simply allows Vapor to provide links to GitHub for each deployment's commit hash. You are not required to provide repository information for Vapor to function.
 
-## Managing Vendors
-
-AWS Lambda has strict limitations on the size of applications running within the environment. Typically, the size of your application should not be a problem. However, if you have a large `vendor` directory, you may receive an error indicating that your project is too large.
-
-In order to mitigate this, Vapor offers a `separate-vendor` deployment option which will upload and store your vendor directory separately from the rest of your application. When fresh application containers are booting, your `vendor` directory will be downloaded and unzipped so that your application can access it. This process only takes 1-2 milliseconds. In addition, this option will dramatically reduce the size of your deployment artifact.
-
-To enable this feature, add the `separate-vendor` directive to the project level of your `Vapor.yml` file:
-
-```yaml
-id: 3
-name: vapor-app
-separate-vendor: true
-```
-
 ## Deleting Projects
 
 You may delete a project using the Vapor UI or the `project:delete` CLI command. The `project:delete` command should be run from the root directory of your project. This command will delete the project in Vapor as well as the AWS Lambda function and AWS API Gateway definition. Any custom resources defined for the project, such as S3 buckets, will not be deleted by Vapor in case they are being used by other projects. If you wish to delete them, you may do so manually from the AWS management console.


### PR DESCRIPTION
This pull request adds a recommendation about the usage of docker images instead of the "separate-vendor" flag.