### PR TITLE
Improves visualize logs section

### DIFF
--- a/1.0/resources/logs.md
+++ b/1.0/resources/logs.md
@@ -6,11 +6,11 @@
 
 As you may know, Laravel provides support for a variety of logging services. By default, when using Vapor, your application will use the AWS CloudWatch service when logging messages.
 
-## Visualizing Logs
+## Viewing Logs
 
 If you have installed the [Vapor UI dashboard package](./../introduction.html#installing-the-vapor-ui-dashboard), you may access the `/vapor-ui` URI to view and search your application's logs stored in AWS CloudWatch.
 
-Alternatively, you may visualize logs directly in AWS CloudWatch at AWS console > Lambda > Locate the lambda for your project (vapor-{projectName}-{environmentName}) > Monitoring > View logs in CloudWatch.
+Alternatively, you may view logs directly in AWS CloudWatch. To do so, navigate to the AWS console's "Lambda" dashboard. Then, locate the Lambda for your project (vapor-{projectName}-{environmentName}). Then, you may click the "View logs in CloudWatch" link within the Lambda's "Monitoring" tab.
 
 :::tip Infrastructure Logs
 

--- a/1.0/resources/logs.md
+++ b/1.0/resources/logs.md
@@ -10,19 +10,9 @@ As you may know, Laravel provides support for a variety of logging services. By 
 
 If you have installed the [Vapor UI dashboard package](./../introduction.html#installing-the-vapor-ui-dashboard), you may access the `/vapor-ui` URI to view and search your application's logs stored in AWS CloudWatch.
 
+Alternatively, you may visualize logs directly in AWS CloudWatch at AWS console > Lambda > Locate the lambda for your project (vapor-{projectName}-{environmentName}) > Monitoring > View logs in CloudWatch.
+
 :::tip Infrastructure Logs
 
 Remember, even if you configure a different logging service for your application logs, the AWS CloudWatch service and Vapor UI will display your infrastructure logs as well. Infrastructure logs may include logs regarding AWS Lambda timeouts, etc.
 :::
-
-### Local Environment
-
-If you would like to use the Vapor UI dashboard in your local environment to view your production application's logs, you must set the following environment variables:
-
-```
-AWS_ACCESS_KEY_ID=
-AWS_DEFAULT_REGION=
-AWS_SECRET_ACCESS_KEY=
-VAPOR_ENVIRONMENT=
-VAPOR_PROJECT=
-```


### PR DESCRIPTION
This pull request improves visualize logs section:

- Adds note that users can visualize logs directly at "AWS CloudWatch". This may be useful when users can't visualize the logs on Vapor UI.
- Removes section that says that Vapor UI can be used locally. This section really don't makes sense and may confuse users as the dashboard will be displaying mixed information from AWS environment or local environment. Example: Logs are from CloudWatch, but failed jobs are from their local mysql.