### PR TITLE
Clarify the concurrency documentation

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -221,7 +221,7 @@ environments:
 
 ## Concurrency
 
-By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 requests executing at the same time at any given moment for all of your lambda functions in a given region. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration. Additionally, if you need more than 1,000 concurrent requests, you can submit a limit increase request in the AWS Support Center console. All of your applications within the same AWS region will share from the pool of max concurrent requests.
+By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 requests executing at the same time at any given moment across all of your AWS Lambda functions in a given region. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration. Additionally, if you need more than 1,000 concurrent requests, you can submit a limit increase request in the AWS Support Center console.
 
 While maximum performance is certainly appealing, in some situations it may make sense to set this value to the maximum concurrency you reasonably expect for your particular application. Otherwise, a DDoS attack against your application could result in larger than expected AWS costs:
 

--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -221,7 +221,7 @@ environments:
 
 ## Concurrency
 
-By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 requests executing at the same time at any given moment. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration. Additionally, if you need more than 1,000 concurrent requests, you can submit a limit increase request in the AWS Support Center console.
+By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 requests executing at the same time at any given moment for all of your lambda functions in a given region. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration. Additionally, if you need more than 1,000 concurrent requests, you can submit a limit increase request in the AWS Support Center console. All of your applications within the same AWS region will share from the pool of max concurrent requests.
 
 While maximum performance is certainly appealing, in some situations it may make sense to set this value to the maximum concurrency you reasonably expect for your particular application. Otherwise, a DDoS attack against your application could result in larger than expected AWS costs:
 


### PR DESCRIPTION
In AWS the concurrency limit is region wide, not function specific, so all functions contribute to the maximum concurrency limit.

For example, if you have three applications in vapor all in the same region with a staging and a production environment all 9 lambda functions will share the max limit.

We ran into an issue where one of our applications _went viral_ and it ended up taking down our other vapor applications because they all share the limit.

While requesting a limit increase at AWS and setting that limit within our various applications I discovered that the limits are indeed shared across all functions within a region, and not a max limit per application.