### PR TITLE
Add OpenSSL clarification

### DIFF
--- a/1.0/projects/development.md
+++ b/1.0/projects/development.md
@@ -36,10 +36,64 @@ Route::get('/', function (LambdaEvent $event) {
 ```
 ## Configuring OpenSSL
 
-To use certain OpenSSL functions, such as [openssl_pkey_new](https://www.php.net/manual/en/function.openssl-pkey-new.php), you'll need to provide an openssl.cnf file. Because Vapor injects environment variables into the underlying lambda container instead of loading them at runtime, the path to the file can be provided in your `.env` file
+To use certain OpenSSL functions, such as [openssl_pkey_new](https://www.php.net/manual/en/function.openssl-pkey-new.php), you'll need to provide an openssl.cnf file. Because Vapor injects environment variables into the underlying lambda container instead of loading them at runtime, the path to the file can be provided in your `.env` file.
+
+This will reference openssl.cnf in the root of your project:
 
 ```
 OPENSSL_CONF="/var/task/openssl.cnf"
+```
+
+
+An example openssl.cnf is available below.
+
+```
+dir = certificates
+
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+serial = $dir/serial
+database = $dir/index.txt
+new_certs_dir = $dir/newcerts
+certificate  = $dir/cacert.pem
+private_key = $dir/private/cakey.pem
+default_days = 36500
+default_md  = sha256
+preserve = no
+email_in_dn  = no
+nameopt = default_ca
+certopt = default_ca
+policy = policy_match
+
+[ policy_match ]
+commonName = supplied
+countryName = optional
+stateOrProvinceName = optional
+organizationName = optional
+organizationalUnitName = optional
+emailAddress = optional
+
+[ req ]
+default_bits = 2048
+default_keyfile = priv.pem
+default_md = sha256
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+encyrpt_key = no
+
+[ req_distinguished_name ]
+
+[ v3_ca ]
+basicConstraints = CA:TRUE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+
 ```
 
 :::warning Local functionality

--- a/1.0/projects/development.md
+++ b/1.0/projects/development.md
@@ -34,3 +34,15 @@ Route::get('/', function (LambdaEvent $event) {
     // ..
 });
 ```
+## Configuring OpenSSL
+
+To use certain OpenSSL functions, such as [openssl_pkey_new](https://www.php.net/manual/en/function.openssl-pkey-new.php), you'll need to provide an openssl.cnf file. Because Vapor injects environment variables into the underlying lambda container instead of loading them at runtime, the path to the file can be provided in your `.env` file
+
+```
+OPENSSL_CONF="/var/task/openssl.cnf"
+```
+
+:::warning Local functionality
+
+Because environment variables locally get loaded at a later stage, this will not override the config on a local environment.
+:::


### PR DESCRIPTION
OpenSSL configuration is overridden in a special way in Vapor. This documents how you can do it.

Based on this issue: https://github.com/laravel/vapor-php-build/issues/72#issuecomment-815114136