### PR TITLE
Add warning about memory increments

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -237,7 +237,7 @@ environments:
 
 :::warning Memory Increments
 
-To configure the memory for your function, set a value between 128 MB and 10,240 MB in 64-MB increments.
+When configuring the memory for your Lambda function, you may define a value between 128 MB and 10,240 MB in 64-MB increments.
 :::
 
 ## Concurrency

--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -235,6 +235,11 @@ environments:
             - 'composer install --no-dev'
 ```
 
+:::warning Memory Increments
+
+To configure the memory for your function, set a value between 128 MB and 10,240 MB in 64-MB increments.
+:::
+
 ## Concurrency
 
 By default, Vapor will allow your application to process web requests at max concurrency, which is typically 1,000 requests executing at the same time at any given moment across all of your AWS Lambda functions in a given region. If you would like to reduce the maximum web concurrency, you may define the `concurrency` option in the environment's `vapor.yml` configuration. Additionally, if you need more than 1,000 concurrent requests, you can submit a limit increase request in the AWS Support Center console.


### PR DESCRIPTION
AWS specifies that you can set function memory to any value between 128MB -10240MB in 1MB increments. However, Laravel Vapor only allows values between 128M -10240MB in 64MB increments. Using a value that is not evenly divisible by 64 will cause a deployment validation error.

This was discovered while trying to test a function with 1vCPU which requires at least 1769MB of memory. https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html