### PR TITLE
Adds "Example With GitHub Actions"

### DIFF
--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -233,7 +233,7 @@ vapor deploy production --commit="${CI_COMMIT_ID}" --message="${CI_MESSAGE}"
 
 ### Example with GitHub Actions
 
-If [GitHub Actions](https://github.com/features/actions) is your CI platform of choice, you may follow these steps so you can have a basic deployment pipeline using GitHub Actions that deploys your application when someone pushes to `master`:
+If [GitHub Actions](https://github.com/features/actions) is your CI platform of choice, you may follow these steps so you can have a basic deployment pipeline using GitHub Actions that deploys your application when someone pushes a commit to the `master` branch:
 
 1. First, and as mentioned before, add the `VAPOR_API_TOKEN` environment variable to your "GitHub > Project Settings > Secrets" so GitHub can authenticate with Vapor while running actions.
 
@@ -266,6 +266,4 @@ jobs:
           VAPOR_API_TOKEN: ${{ secrets.VAPOR_API_TOKEN }}
 ```
 
-3. Finally, commit & push the `deploy.yml` file.
-
-Feel free to tweak the `deploy.yml` file to fit your own needs. As an example, your deployment depends on `npm`, you will need an extra step to install `npm`.
+3. Finally, edit the `deploy.yml` file to fit your deployment needs, as it may require `npm`, etc. Once you are done, commit and push the `deploy.yml` file to `master` so GitHub actions can run the first deployment job.

--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -266,4 +266,4 @@ jobs:
           VAPOR_API_TOKEN: ${{ secrets.VAPOR_API_TOKEN }}
 ```
 
-3. Finally, edit the `deploy.yml` file to fit your deployment needs, as it may require `npm`, etc. Once you are done, commit and push the `deploy.yml` file to `master` so GitHub actions can run the first deployment job.
+3. Finally, edit the `deploy.yml` file to fit your deployment needs, as it may require a different PHP version or a library like `npm`. Once you are done, commit and push the `deploy.yml` file to `master` so GitHub actions can run the first deployment job.

--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -233,11 +233,11 @@ vapor deploy production --commit="${CI_COMMIT_ID}" --message="${CI_MESSAGE}"
 
 ### Example With GitHub Actions
 
-If [GitHub Actions](https://github.com/features/actions) is your CI platform of choice, you may follow these steps so you can have a basic deployment pipeline using GitHub Actions that deploys your application when someone pushes a commit to the `master` branch:
+If your application uses [GitHub Actions](https://github.com/features/actions) as its CI platform, the following guidelines will assist you in configuring Vapor deployments so that your application is automatically deployed when someone pushes a commit to the `master` branch:
 
-1. First, and as mentioned before, add the `VAPOR_API_TOKEN` environment variable to your "GitHub > Project Settings > Secrets" so GitHub can authenticate with Vapor while running actions.
+1. First, add the `VAPOR_API_TOKEN` environment variable to your "GitHub > Project Settings > Secrets" settings so that GitHub can authenticate with Vapor while running actions.
 
-2. Next, create a file on the directory `your-project/.github/workflows` with the name `deploy.yml` and the following contents:
+2. Next, create a `deploy.yml` file within the `your-project/.github/workflows` directory. The file should have the following contents:
 
 ```yml
 name: Deploy
@@ -266,4 +266,4 @@ jobs:
           VAPOR_API_TOKEN: ${{ secrets.VAPOR_API_TOKEN }}
 ```
 
-3. Finally, edit the `deploy.yml` file to fit your deployment needs, as it may require a different PHP version or a library like `npm`. Once you are done, commit and push the `deploy.yml` file to `master` so GitHub actions can run the first deployment job.
+3. Finally, you can edit the `deploy.yml` file to fit your application's deployment needs, as it may require a different PHP version or a library like `npm`. Once you are done, commit and push the `deploy.yml` file to `master` so GitHub Actions can run the first deployment job.

--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -230,3 +230,42 @@ Some CI platforms expose the Git commit information as environment variables dur
 ```sh
 vapor deploy production --commit="${CI_COMMIT_ID}" --message="${CI_MESSAGE}"
 ```
+
+### Example with GitHub Actions
+
+If [GitHub Actions](https://github.com/features/actions) is your CI platform of choice, you may follow these steps so you can have a basic deployment pipeline using GitHub Actions that deploys your application when someone pushes to `master`:
+
+1. First, and as mentioned before, add the `VAPOR_API_TOKEN` environment variable to your "GitHub > Project Settings > Secrets" so GitHub can authenticate with Vapor while running actions.
+
+2. Next, create a file on the directory `your-project/.github/workflows` with the name `deploy.yml` and the following contents:
+
+```yml
+name: Deploy
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          tools: composer:v2
+          coverage: none
+      - name: Require Vapor CLI
+        run: composer global require laravel/vapor-cli
+      - name: Deploy Environment
+        run: vapor deploy
+        env:
+          VAPOR_API_TOKEN: ${{ secrets.VAPOR_API_TOKEN }}
+```
+
+3. Finally, commit & push the `deploy.yml` file.
+
+Feel free to tweak the `deploy.yml` file to fit your own needs. As an example, your deployment depends on `npm`, you will need an extra step to install `npm`.

--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -231,7 +231,7 @@ Some CI platforms expose the Git commit information as environment variables dur
 vapor deploy production --commit="${CI_COMMIT_ID}" --message="${CI_MESSAGE}"
 ```
 
-### Example with GitHub Actions
+### Example With GitHub Actions
 
 If [GitHub Actions](https://github.com/features/actions) is your CI platform of choice, you may follow these steps so you can have a basic deployment pipeline using GitHub Actions that deploys your application when someone pushes a commit to the `master` branch:
 


### PR DESCRIPTION
This pull request adds an example about how to issue a Vapor deployment (push to deploy) from GitHub actions.

Note: this example works with docker based deployments.