### PR TITLE
Uses v1/v2 instead of 1.0/2.0

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -526,9 +526,9 @@ COPY . /var/task
 
 ## Gateway Versions
 
-By default, Vapor routes HTTP traffic to your serverless applications using AWS API Gateway. Your application may run on either API Gateway 1.0 or API Gateway 2.0 (HTTP APIs). By default, applications deploy using API Gateway 1.0 as it provides a fuller feature set such as wildcard domains, automatic HTTP to HTTPS redirection, and more.
+By default, Vapor routes HTTP traffic to your serverless applications using AWS API Gateway v1 (REST APIs). Your application may run on either API Gateway v1 (REST APIs) or API Gateway v2 (HTTP APIs). By default, applications deploy using API Gateway v1 as it provides a fuller feature set such as Vapor's managed Firewall, and more.
 
-However, API Gateway 2.0 offers a cost reduction per million requests to your application ($1.00 per million vs. $3.50 per million). If you would like to use API Gateway 2.0, you may specify the `gateway-version` configuration option for a given environment in your `vapor.yml` file:
+However, API Gateway v2 offers a cost reduction per million requests to your application ($1.00 per million vs. $3.50 per million). If you would like to use API Gateway v2, you may specify the `gateway-version` configuration option for a given environment in your `vapor.yml` file:
 
 ```yaml
 id: 2
@@ -540,9 +540,9 @@ environments:
             - 'composer install --no-dev'
 ```
 
-### HTTP to HTTPS Redirection With API Gateway 2.0
+### HTTP to HTTPS Redirection With API Gateway v2
 
-If you choose to use API Gateway 2.0 and would like to support HTTP to HTTPS redirection, we currently suggest using [Cloudflare](https://cloudflare.com) as an external DNS provider for your Vapor application. Cloudflare not only provides DNS, but serves as a reverse proxy to your application and features an option for automatic HTTP to HTTPS redirection.
+If you choose to use API Gateway v2 and would like to support HTTP to HTTPS redirection, we currently suggest using [Cloudflare](https://cloudflare.com) as an external DNS provider for your Vapor application. Cloudflare not only provides DNS, but serves as a reverse proxy to your application and features an option for automatic HTTP to HTTPS redirection.
 
 After a Vapor deployment is completed, Vapor will provide you with CNAME records for the domain(s) associated with your environment. These records will point the domain to your Lambda application. You should manually add these values as CNAME records within the Cloudflare DNS dashboard.
 


### PR DESCRIPTION
External documentation always reference to API Gateway v1 instead of API Gateway 1.0.