### PR TITLE
Adds `tmp-storage` documentation

### DIFF
--- a/1.0/resources/storage.md
+++ b/1.0/resources/storage.md
@@ -145,9 +145,9 @@ When developing locally, `Vapor.store` will upload to the bucket specified by th
 
 ## Temporary Storage
 
-Vapor - via AWS Lambda - provides a file system for your application code to use at `/tmp`. By default, this space has a fixed size of 512 MB, and the information on it is preserved for the lifetime of each request, CLI command, or queue job.
+Your application may store temporary files within the `/tmp` directory. By default, this directory has a fixed size of 512 MB, and the information on it is preserved for the lifetime of each request, CLI command, or queue job.
 
-You may increase or decrease the configured temporary storage size using the `tmp-storage`, `cli-tmp-storage`, and `queue-tmp-storage` options in your environment's `vapor.yml` configuration and a value between 512 MB and 10,240 MB:
+You may increase or decrease the configured temporary storage size using the `tmp-storage`, `cli-tmp-storage`, and `queue-tmp-storage` options in your environment's `vapor.yml` configuration. These configuration options accepts values between 512 MB and 10,240 MB:
 
 ```yaml
 id: 2

--- a/1.0/resources/storage.md
+++ b/1.0/resources/storage.md
@@ -145,9 +145,7 @@ When developing locally, `Vapor.store` will upload to the bucket specified by th
 
 ## Temporary Storage
 
-Your application may store temporary files within the `/tmp` directory. By default, this directory has a fixed size of 512 MB, and the information on it is preserved for the lifetime of each request, CLI command, or queue job.
-
-You may increase or decrease the configured temporary storage size using the `tmp-storage`, `cli-tmp-storage`, and `queue-tmp-storage` options in your environment's `vapor.yml` configuration. These configuration options accepts values between 512 MB and 10,240 MB:
+Your application may store temporary files within the `/tmp` directory. By default, this directory has a fixed size of 512 MB, and the information on it is preserved for the lifetime of each request, CLI command, or queue job. You may increase or decrease the configured temporary storage size using the `tmp-storage`, `cli-tmp-storage`, and `queue-tmp-storage` options in your environment's `vapor.yml` configuration. These configuration options accepts values between 512 MB and 10,240 MB:
 
 ```yaml
 id: 2

--- a/1.0/resources/storage.md
+++ b/1.0/resources/storage.md
@@ -145,7 +145,7 @@ When developing locally, `Vapor.store` will upload to the bucket specified by th
 
 ## Temporary Storage
 
-Your application may store temporary files within the `/tmp` directory. By default, this directory has a fixed size of 512 MB, and the information on it is preserved for the lifetime of each request, CLI command, or queue job. You may increase or decrease the configured temporary storage size using the `tmp-storage`, `cli-tmp-storage`, and `queue-tmp-storage` options in your environment's `vapor.yml` configuration. These configuration options accepts values between 512 MB and 10,240 MB:
+Your application may store temporary files within the `/tmp` directory. By default, this directory has a fixed size of 512 MB, and the information on it is preserved for the lifetime of each request, CLI command, or queue job. You may increase or decrease the configured temporary storage size using the `tmp-storage`, `cli-tmp-storage`, and `queue-tmp-storage` options in your environment's `vapor.yml` configuration. These configuration options accept values between 512 MB and 10,240 MB:
 
 ```yaml
 id: 2

--- a/1.0/resources/storage.md
+++ b/1.0/resources/storage.md
@@ -142,3 +142,21 @@ When developing locally, `Vapor.store` will upload to the bucket specified by th
    }
 ]
 ```
+
+## Temporary Storage
+
+Vapor - via AWS Lambda - provides a file system for your application code to use at `/tmp`. By default, this space has a fixed size of 512 MB, and the information on it is preserved for the lifetime of each request, CLI command, or queue job.
+
+You may increase or decrease the configured temporary storage size using the `tmp-storage`, `cli-tmp-storage`, and `queue-tmp-storage` options in your environment's `vapor.yml` configuration and a value between 512 MB and 10,240 MB:
+
+```yaml
+id: 2
+name: vapor-laravel-app
+environments:
+    production:
+        tmp-storage: 1024
+        cli-tmp-storage: 512
+        queue-tmp-storage: 10240
+        build:
+            - 'composer install --no-dev'
+```


### PR DESCRIPTION
This pull request adds documentation about the new `tmp-storage` option.