### PR TITLE
Public databases with proxy require nat gateway

### DIFF
--- a/1.0/resources/databases.md
+++ b/1.0/resources/databases.md
@@ -58,12 +58,12 @@ To attach a database to an environment, add a `database` key to the environment'
 id: 3
 name: vapor-app
 environments:
-    production:
-        database: my-application-db
-        build:
-            - 'composer install --no-dev'
-        deploy:
-            - 'php artisan migrate --force'
+  production:
+    database: my-application-db
+    build:
+      - "composer install --no-dev"
+    deploy:
+      - "php artisan migrate --force"
 ```
 
 ### Connecting To Private Databases Locally
@@ -100,13 +100,13 @@ Next, you may instruct an environment to use the proxy associated with the datab
 id: 3
 name: vapor-app
 environments:
-    production:
-        database: my-application-db
-        database-proxy: true
-        build:
-            - 'composer install --no-dev'
-        deploy:
-            - 'php artisan migrate --force'
+  production:
+    database: my-application-db
+    database-proxy: true
+    build:
+      - "composer install --no-dev"
+    deploy:
+      - "php artisan migrate --force"
 ```
 
 You can delete the proxy at any time using the Vapor UI or the `database:delete-proxy` CLI command. Before deleting a proxy, make sure none of your applications are using the associated proxy:
@@ -119,6 +119,8 @@ vapor database:delete-proxy my-application-db
 
 Before considering the usage of database proxies in Vapor, please consult Amazon's [list of limitations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy.html#rds-proxy.limitations).
 :::
+
+_**Note:** When a proxy is added to a public database, Vapor will place any application that uses them in a network with a [NAT Gateway](./networks.md#nat-gateways)._
 
 ## Database Users
 
@@ -134,13 +136,13 @@ You may instruct an environment to connect to a database as a given user using t
 id: 3
 name: vapor-app
 environments:
-    production:
-        database: my-application-db
-        database-user: user-2
-        build:
-            - 'composer install --no-dev'
-        deploy:
-            - 'php artisan migrate --force'
+  production:
+    database: my-application-db
+    database-user: user-2
+    build:
+      - "composer install --no-dev"
+    deploy:
+      - "php artisan migrate --force"
 ```
 
 :::tip Database Password Rotation
@@ -170,7 +172,6 @@ When restoring a database, a new database is created with the same configuration
 
 Once you are satisfied with the database restoration, you may delete the old database.
 
-
 ## Upgrading Databases
 
 You may upgrade a Vapor managed MySQL database via the Vapor UI or the `database:upgrade` CLI command. When upgrading a database, a new database is created with the same configuration and credentials as the original database:
@@ -181,7 +182,7 @@ vapor database:upgrade current-database-name new-database-name
 
 Keep in mind that major version upgrades can contain database changes that are not backward-compatible with existing applications. For that reason, we recommend that you thoroughly test the new upgraded database version before attaching it to a production environment. The original database will not be affected by this operation at any point.
 
-Upgrading a database can take several hours for large databases. Therefore, if you plan to attach the new database to a production environment, you may want to place any affected environments in maintenance mode first. Once the newly upgraded database is available, you may start using it by attaching it to an environment. 
+Upgrading a database can take several hours for large databases. Therefore, if you plan to attach the new database to a production environment, you may want to place any affected environments in maintenance mode first. Once the newly upgraded database is available, you may start using it by attaching it to an environment.
 
 Of course, once you are satisfied with the database upgrade, you may delete the original database.
 

--- a/1.0/resources/networks.md
+++ b/1.0/resources/networks.md
@@ -14,10 +14,10 @@ Typically, you do not need to manually add a `network` directive to your `vapor.
 id: 3
 name: vapor-app
 environments:
-    production:
-        network: my-network
-        build:
-            - 'composer install --no-dev'
+  production:
+    network: my-network
+    build:
+      - "composer install --no-dev"
 ```
 
 ## Jumpboxes
@@ -73,12 +73,11 @@ To attach a load balancer to an environment, add a `balancer` key to the environ
 id: 3
 name: vapor-app
 environments:
-    production:
-        balancer: my-balancer
-        build:
-            - 'composer install --no-dev'
+  production:
+    balancer: my-balancer
+    build:
+      - "composer install --no-dev"
 ```
-
 
 :::tip Load Balancer Certificates
 

--- a/1.0/resources/networks.md
+++ b/1.0/resources/networks.md
@@ -22,7 +22,7 @@ environments:
 
 ## Jumpboxes
 
-Some Vapor resources, such as private databases or cache clusters, may not be accessed from the public Internet. Instead, they can only be accessed by a machine within their network. This can make it cumbersome to inspect and manipulate these resources during development. To mitigate this inconvenience, Vapor allows you to create jumpboxes. Jumpboxes are very small, SSH accessible servers that are placed within your private network.
+Some Vapor resources, such as private databases, or cache clusters, may not be accessed from the public Internet. Instead, they can only be accessed by a machine within their network. This can make it cumbersome to inspect and manipulate these resources during development. To mitigate this inconvenience, Vapor allows you to create jumpboxes. Jumpboxes are very small, SSH accessible servers that are placed within your private network.
 
 You may create a jumpbox via the Vapor UI's network detail screen or using the `jump` CLI command:
 
@@ -41,15 +41,15 @@ For practical examples of using jumpboxes to make your serverless life easier, c
 
 ### What Are They?
 
-If your application interacts with a private database or a cache cluster, your network will require a NAT Gateway. It sounds complicated, but don't worry, Vapor takes care of the heavy lifting. In summary, when a serverless application needs to interact with one of these resources, AWS requires us to place that application within that region's network. By default, this network has no access to the outside Internet, meaning any outgoing API calls from your application will fail. Not good.
+If your application interacts with a private database, a public database with a proxy or a cache cluster, your network will require a NAT Gateway. It sounds complicated, but don't worry, Vapor takes care of the heavy lifting. In summary, when a serverless application needs to interact with one of these resources, AWS requires us to place that application within that region's network. By default, this network has no access to the outside Internet, meaning any outgoing API calls from your application will fail. Not good.
 
 ### Managing NAT Gateways
 
-Anytime you deploy an application that lists a private database or cache cluster as an attached resource within its `vapor.yml` file, Vapor will automatically ensure that the network associated with that database / cache contains a NAT Gateway. If it doesn't, Vapor will automatically begin provisioning one. Unfortunately, AWS bills for NAT Gateways by the hour, resulting in a monthly fee of about $32 / month.
+Anytime you deploy an application that lists a private database, a public database with a proxy or cache cluster as an attached resource within its `vapor.yml` file, Vapor will automatically ensure that the network associated with that database / cache contains a NAT Gateway. If it doesn't, Vapor will automatically begin provisioning one. Unfortunately, AWS bills for NAT Gateways by the hour, resulting in a monthly fee of about $32 / month.
 
 To totally avoid using NAT Gateways, you can use publicly accessible RDS databases (Vapor automatically assigns a long, random password) and a [DynamoDB cache table](./caches.md#dynamodb-caches), which Vapor automatically creates for each of your projects.
 
-When you delete a private database or cache cluster, and that resource is the last private resource on a given network, Vapor will automatically schedule a job to remove the NAT Gateway from the associated network, thus removing it from your AWS bill. However, you may also manually add or remove NAT Gateways from your networks using the Vapor UI or using the `network:nat` and `network:delete-nat` CLI commands.
+When you delete a private database, a public database with a proxy or cache cluster, and that resource is the last private resource on a given network, Vapor will automatically schedule a job to remove the NAT Gateway from the associated network, thus removing it from your AWS bill. However, you may also manually add or remove NAT Gateways from your networks using the Vapor UI or using the `network:nat` and `network:delete-nat` CLI commands.
 
 ## Load Balancers
 


### PR DESCRIPTION
When a proxy is added to a public database, Vapor will place any application that uses them in a network with a NAT Gateway

This may incur in an unexpected was billing invoice.