### PR TITLE
Clarifies that NAT does not get removed

### DIFF
--- a/1.0/resources/networks.md
+++ b/1.0/resources/networks.md
@@ -47,9 +47,7 @@ If your application interacts with a private database or a cache cluster, your n
 
 Anytime you deploy an application that lists a private database or cache cluster as an attached resource within its `vapor.yml` file, Vapor will automatically ensure that the network associated with that database / cache contains a NAT Gateway. If it doesn't, Vapor will automatically begin provisioning one. Unfortunately, AWS bills for NAT Gateways by the hour, resulting in a monthly fee of about $32 / month.
 
-To totally avoid using NAT Gateways, you can use publicly accessible RDS databases (Vapor automatically assigns a long, random password) and a [DynamoDB cache table](./caches.md#dynamodb-caches), which Vapor automatically creates for each of your projects.
-
-When you delete a private database or cache cluster, and that resource is the last private resource on a given network, Vapor will automatically schedule a job to remove the NAT Gateway from the associated network, thus removing it from your AWS bill. However, you may also manually add or remove NAT Gateways from your networks using the Vapor UI or using the `network:nat` and `network:delete-nat` CLI commands.
+To totally avoid using NAT Gateways, you can use publicly accessible RDS databases (Vapor automatically assigns a long, random password) and a [DynamoDB cache table](./caches.md#dynamodb-caches), which Vapor automatically creates for each of your projects. You may also manually add or remove NAT Gateways from your networks using the Vapor UI or using the `network:nat` and `network:delete-nat` CLI commands.
 
 ## Load Balancers
 


### PR DESCRIPTION
This pull request clarifies that the NAT Gateway does not get automatically deleted when deleting a private resource.