### PR TITLE
Updates database and queue docs

### DIFF
--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -73,6 +73,11 @@ You can review the logs associated with the failing hook using the `hook:log` co
 vapor hook:log {DEPLOYMENT_HOOK_ID}
 ```
 
+:::warning Database Migrations
+
+[Native Vapor runtimes](https://docs.vapor.build/1.0/projects/environments.html#runtime) do not support squashing migrations. Should you wish to utilise the `schema:dump` command, you may take advantage of Vapor's [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#docker-runtimes)
+:::
+
 ## Assets
 
 During deployment, Vapor will automatically extract all of the assets in your Laravel project's `public` directory and upload them to S3. In addition, Vapor will create a AWS CloudFront (CDN) distribution to distribute these assets efficiently around the world.

--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -75,7 +75,7 @@ vapor hook:log {DEPLOYMENT_HOOK_ID}
 
 :::warning Database Migrations
 
-[Native Vapor runtimes](https://docs.vapor.build/1.0/projects/environments.html#runtime) do not support squashing migrations. Should you wish to utilise the `schema:dump` command, you may take advantage of Vapor's [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#docker-runtimes)
+[Native Vapor runtimes](https://docs.vapor.build/1.0/projects/environments.html#runtime) do not support [squashed migrations](https://laravel.com/docs/migrations#squashing-migrations). Should you wish to utilise this feature of Laravel, you may take advantage of Vapor's [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#docker-runtimes)
 :::
 
 ## Assets

--- a/1.0/projects/deployments.md
+++ b/1.0/projects/deployments.md
@@ -73,9 +73,9 @@ You can review the logs associated with the failing hook using the `hook:log` co
 vapor hook:log {DEPLOYMENT_HOOK_ID}
 ```
 
-:::warning Database Migrations
+:::warning Squashed Database Migrations
 
-[Native Vapor runtimes](https://docs.vapor.build/1.0/projects/environments.html#runtime) do not support [squashed migrations](https://laravel.com/docs/migrations#squashing-migrations). Should you wish to utilise this feature of Laravel, you may take advantage of Vapor's [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#docker-runtimes)
+[Native Vapor runtimes](https://docs.vapor.build/1.0/projects/environments.html#runtime) do not support [squashed migrations](https://laravel.com/docs/migrations#squashing-migrations). If you wish to utilize this feature of Laravel, you may take advantage of Vapor's [Docker based deployments](https://docs.vapor.build/1.0/projects/environments.html#docker-runtimes)
 :::
 
 ## Assets

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -33,6 +33,11 @@ environments:
             - invoices
 ```
 
+:::danger Duplicate Queue Names
+
+When using custom queue names, it is important to ensure the names are unique between projects and environments. Vapor automatically configures a Lambda function from each environment to process jobs from the queue. When the queue is shared, there is no guarantee which environment will process it.
+:::
+
 ### Disabling The Queue
 
 If your application does not use queues, you may set the environment's `queues` option to `false`:

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 :::danger Duplicate Queue Names
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. Vapor automatically configures a Lambda function from each environment to process jobs from the queue. When the queue is shared, there is no guarantee which environment will process it.
+When using custom queue names, it is important to ensure the names are unique between projects and environments. Vapor automatically configures a Lambda function for each environment to process jobs from the queue. When the queue is shared, there is no guarantee which environment will process jobs on that queue.
 :::
 
 ### Disabling The Queue


### PR DESCRIPTION
This PR adds two things:

1. Warning when attempting to use squashed migrations
2. Provides a warning to users who attempt to use duplicate queue names between environments