### PR TITLE
Update introduction.md to explain /vapor-ui and local environment

### DIFF
--- a/1.0/introduction.md
+++ b/1.0/introduction.md
@@ -82,7 +82,7 @@ composer require laravel/vapor-core --update-with-dependencies
 
 ## Installing The Vapor UI Dashboard
 
-In addition, you may want to install the `laravel/vapor-ui` [package](https://github.com/laravel/vapor-ui). This package provides a beautiful dashboard through your application that allows you to monitor your application's logs and failed queue jobs. The Vapor UI dashboard package can be installed in your project using Composer:
+In addition, you may want to install the `laravel/vapor-ui` [package](https://github.com/laravel/vapor-ui). This package provides a beautiful dashboard through your application that allows you to monitor your application's logs and failed queue jobs, at the `/vapor-ui` URI. The Vapor UI dashboard package can be installed in your project using Composer:
 
 ```bash
 composer require laravel/vapor-ui
@@ -93,6 +93,8 @@ After installing Vapor UI, you may publish its assets using the `vapor-ui:instal
 ```bash
 php artisan vapor-ui:install
 ```
+
+Note that this dashboard is intended to be visualized on an AWS runtime. Therefore, you must do a: `vapor deploy`, and visit the dashboard via your vanity URL. The `/vapor-ui` URL will return a 404 if used on your local environment.
 
 ### Dashboard Authorization
 

--- a/1.0/introduction.md
+++ b/1.0/introduction.md
@@ -82,7 +82,7 @@ composer require laravel/vapor-core --update-with-dependencies
 
 ## Installing The Vapor UI Dashboard
 
-In addition, you may want to install the `laravel/vapor-ui` [package](https://github.com/laravel/vapor-ui). This package provides a beautiful dashboard through your application that allows you to monitor your application's logs and failed queue jobs, at the `/vapor-ui` URI. The Vapor UI dashboard package can be installed in your project using Composer:
+In addition, you may want to install the `laravel/vapor-ui` [package](https://github.com/laravel/vapor-ui). This package provides a beautiful dashboard through your application that allows you to monitor your application's logs and failed queue jobs. After deploying your application to Vapor, the dashboard will be available at the `/vapor-ui` URI. The Vapor UI dashboard package can be installed in your project using Composer:
 
 ```bash
 composer require laravel/vapor-ui
@@ -94,7 +94,7 @@ After installing Vapor UI, you may publish its assets using the `vapor-ui:instal
 php artisan vapor-ui:install
 ```
 
-Note that this dashboard is intended to be visualized on an AWS runtime. Therefore, you must do a: `vapor deploy`, and visit the dashboard via your vanity URL. The `/vapor-ui` URL will return a 404 if used on your local environment.
+Of course, you will need to deploy your application to begin using the dashboard. After deploying your application to Vapor, the dashboard will be available at the `/vapor-ui` URI.
 
 ### Dashboard Authorization
 


### PR DESCRIPTION
The setup documentation doesn't mention that the /vapor-ui URI is only intended for use in an AWS environment, deployed via `vapor deploy`.

This PR adds further documentation to explain that it's intended for an AWS environment, and will show a 404 page when used on a local environment.

This felt necessary as otherwise, when first installing Vapor UI, it feels like it hasn't worked, and time is spent debugging and researching why `/vapor-ui` is inaccessible. This note helps avoid that time, by noting that it won't be accessible until deployed to an AWS environment.

This was noted in https://github.com/laravel/vapor-ui/issues/11 as well, with a request from Nuno to raise a proposal to update the docs