### PR TITLE
Added Vapor down secret documentation

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -277,6 +277,26 @@ When an environment is in maintenance mode, the environment's custom domain will
 
 You may customize the maintenance mode splash screen for your application by placing a `503.html` file in your application's root directory. In addition, you may also place a `503.json` file in your application's root directory for requests asking for JSON responses.
 
+### Bypassing Maintenance Mode
+
+You may find it useful to be able to access your site on it's custom domain, rather than the vanity domain, whilst in maintenance mode. To do this, you can add a secret when moving your application into maintenance mode, using the `down` command with a secret:
+
+```bash
+vapor down --secret=[Secret Key]
+```
+
+You will then be able to access your site using the secret key like so:
+
+```
+https://example.com/[Secret Key]
+```
+
+To use this feature, you need to ensure that your application is using the following versions or above of these packages:
+
+- `laravel/framework` v8.0+
+- `laravel/vapor-core` v2.9.3+
+- `laravel/vapor-cli` v1.9.4+
+
 ## Commands
 
 Commands allow you to execute an arbitrary Artisan command against an environment. You may issue a command via the Vapor UI or using the `command` CLI command. The `command` command will prompt you for the Artisan command you would like to run:

--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -279,23 +279,17 @@ You may customize the maintenance mode splash screen for your application by pla
 
 ### Bypassing Maintenance Mode
 
-You may find it useful to be able to access your site on it's custom domain, rather than the vanity domain, whilst in maintenance mode. To do this, you can add a secret when moving your application into maintenance mode, using the `down` command with a secret:
+You may find it useful to be able to access your site on its custom domain rather than the vanity domain while in maintenance mode. To accomplish this, you may provide a secret when invoking the `down` command:
 
 ```bash
-vapor down --secret=[Secret Key]
+vapor down --secret="example-secret"
 ```
 
-You will then be able to access your site using the secret key like so:
+You may then access your application using the secret key as the URL path:
 
 ```
-https://example.com/[Secret Key]
+https://example.com/example-secret
 ```
-
-To use this feature, you need to ensure that your application is using the following versions or above of these packages:
-
-- `laravel/framework` v8.0+
-- `laravel/vapor-core` v2.9.3+
-- `laravel/vapor-cli` v1.9.4+
 
 ## Commands
 


### PR DESCRIPTION
Through looking for the Vapor:down --secret documentation, I realised that it was documented on the blog (https://blog.laravel.com/vapor-bypassing-maintenance-mode) and not the official docs, so I've summarised it and added it in for any other users.

Please feel free to rework the wording if it is not correct.