### PR TITLE
[1.x] Adds missing `FILESYSTEM_DISK` environment variable

### DIFF
--- a/1.0/projects/environments.md
+++ b/1.0/projects/environments.md
@@ -93,6 +93,7 @@ Here is the full list of environment variables injected by Vapor on your environ
 | `CACHE_DRIVER`          | DynamoDB, or cache (Redis) resource if exists              |
 | `DB_*`                  | Database (MySQL, Postgresql, etc) resource if exists       |
 | `DYNAMODB_CACHE_TABLE`  | `vapor_cache`                                              |
+| `FILESYSTEM_DISK`       | S3                                                         |
 | `FILESYSTEM_DRIVER`     | S3                                                         |
 | `FILESYSTEM_CLOUD`      | S3                                                         |
 | `LOG_CHANNEL`           | Stderr                                                     |


### PR DESCRIPTION
This pull request adds missing `FILESYSTEM_DISK` environment variable to our docs.