### PR TITLE
Improves "Duplicate Queue Names" section

### DIFF
--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 ### Ensuring Unique Queue Names Across Projects and Environments
 
-When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment, with the values `-staging` and `-production`, and append it to the queue names in your `vapor.yml` file, as shown below:
+When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `-staging` and `-production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
 
 ```yaml
 id: 2

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 :::danger Duplicate Queue Names
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. One easy way to accomplish this is by using the `SQS_SUFFIX` environment variable in each environment. This guarantees that custom queues have a unique name in SQS.
+When using custom queue names, it is important to ensure the names are unique between projects and environments. You can easily accomplish this by using the `SQS_SUFFIX` environment variable in each environment.
 :::
 
 ### Disabling The Queue

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 :::danger Duplicate Queue Names
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. Vapor automatically configures a Lambda function for each environment to process jobs from the queue. When the queue is shared, there is no guarantee which environment will process jobs on that queue.
+When using custom queue names, it is important to ensure the names are unique between projects and environments. One easy way to accomplish this is by using the `SQS_SUFFIX` environment variable in each environment. This guarantees that custom queue names have a unique names in SQS.
 :::
 
 ### Disabling The Queue

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -51,7 +51,7 @@ environments:
             - invoices-staging
 ```
 
-Because it is cumbersome to include these suffixes when dispatching jobs to specific queues in Laravel, Laravel's `sqs` queue configuration includes a `suffix` option that references the `SQS_SUFFIX` environment variable by default. When this option and variable is defined, you may provide the queue names without their suffix when dispatching jobs and Laravel will automatically append the suffix to the queue name when interacting with SQS:
+Because it is cumbersome to include these suffixes when dispatching jobs to specific queues in Laravel, Laravel's `sqs` queue configuration includes a `suffix` option that references the `SQS_SUFFIX` environment variable by default. When this option and variable are defined, you may provide the queue name without its suffix when dispatching jobs and Laravel will automatically append the suffix to the queue name when interacting with SQS:
 
 ```php
 // Environment should include...

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 ### Ensuring Unique Queue Names Across Projects and Environments
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `staging` and `production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
+When using custom queue names, it is important to ensure the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `-staging` and `-production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
 
 ```yaml
 id: 2

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 :::danger Duplicate Queue Names
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. You can easily accomplish this by using the `SQS_SUFFIX` environment variable in each environment.
+When using custom queue names, it is important to ensure the names are unique between projects and environments. You can easily accomplish this by using the `SQS_SUFFIX` environment variable in each environment. For example, setting the `SQS_SUFFIX` environment variable to `-production` for your production environment will ensure all Vapor created production queues are suffixed with `-production`.
 :::
 
 ### Disabling The Queue

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 ### Ensuring Unique Queue Names Across Projects and Environments
 
-When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `staging` and `production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
+When using custom queue names, it is important to ensure the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `staging` and `production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
 
 ```yaml
 id: 2

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -54,8 +54,8 @@ environments:
 Because it is cumbersome to include these suffixes when dispatching jobs to specific queues in Laravel, Laravel's `sqs` queue configuration includes a `suffix` option that references the `SQS_SUFFIX` environment variable by default. When this option and variable is defined, you may provide the queue names without their suffix when dispatching jobs and Laravel will automatically append the suffix to the queue name when interacting with SQS:
 
 ```php
-// Environment...
-SQS_SUFFIX="-production"
+// Environment should include...
+// SQS_SUFFIX="-production"
 
 // Configuration...
 'sqs' => [

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 ### Ensuring Unique Queue Names Across Projects and Environments
 
-When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment and append it to the queue names in your `vapor.yml` file, as shown below:
+When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment, with the values `-staging` and `-production`, and append it to the queue names in your `vapor.yml` file, as shown below:
 
 ```yaml
 id: 2

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -33,10 +33,29 @@ environments:
             - invoices
 ```
 
-:::danger Duplicate Queue Names
+### Ensuring Unique Queue Names Across Projects and Environments
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. You can easily accomplish this by using the `SQS_SUFFIX` environment variable in each environment. For example, setting the `SQS_SUFFIX` environment variable to `-production` for your production environment will ensure all Vapor created production queues are suffixed with `-production`.
-:::
+When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment and append it to the queue names in your `vapor.yml` file, as shown below:
+
+```yaml
+id: 2
+name: vapor-laravel-app
+environments:
+    production:
+        queues:
+            - emails-production
+            - invoices-production
+    staging:
+        queues:
+            - emails-staging
+            - invoices-staging
+```
+
+When dispatching queue jobs, specify the queue name without the `SQS_SUFFIX` value:
+
+```php
+SendInvoice::dispatch($invoice)->onQueue('invoices');
+```
 
 ### Disabling The Queue
 

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -33,9 +33,9 @@ environments:
             - invoices
 ```
 
-### Ensuring Unique Queue Names Across Projects and Environments
+### Queue Names Should Be Unique
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `-staging` and `-production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
+When using custom queue names, it is important to ensure the names are unique between projects and environments. For instance, you can add suffix values such as `-staging` and `-production` to the queue names specified in your application's `vapor.yml` file:
 
 ```yaml
 id: 2
@@ -51,9 +51,22 @@ environments:
             - invoices-staging
 ```
 
-When dispatching queue jobs, specify the queue name without the `SQS_SUFFIX` value:
+Because it is cumbersome to include these suffixes when dispatching jobs to specific queues in Laravel, Laravel's `sqs` queue configuration includes a `suffix` option that references the `SQS_SUFFIX` environment variable by default. When this option and variable is defined, you may provide the queue names without their suffix when dispatching jobs and Laravel will automatically append the suffix to the queue name when interacting with SQS:
 
 ```php
+// Environment...
+SQS_SUFFIX="-production"
+
+// Configuration...
+'sqs' => [
+    'driver' => 'sqs',
+    // ...
+    'queue' => env('SQS_QUEUE', 'invoices'),
+    'suffix' => env('SQS_SUFFIX'),
+    // ...
+],
+
+// Dispatching...
 SendInvoice::dispatch($invoice)->onQueue('invoices');
 ```
 

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 ### Ensuring Unique Queue Names Across Projects and Environments
 
-When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `-staging` and `-production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
+When using the same custom queue names, you will need to ensure that the names are unique between projects and environments. One way to achieve this is to use the `SQS_SUFFIX` environment variable in each environment. For instance, you can add suffix values such as `staging` and `production` to the `SQS_SUFFIX` environment variable, and append it to the queue names specified in your vapor.yml file. A sample configuration is shown below:
 
 ```yaml
 id: 2

--- a/1.0/resources/queues.md
+++ b/1.0/resources/queues.md
@@ -35,7 +35,7 @@ environments:
 
 :::danger Duplicate Queue Names
 
-When using custom queue names, it is important to ensure the names are unique between projects and environments. One easy way to accomplish this is by using the `SQS_SUFFIX` environment variable in each environment. This guarantees that custom queue names have a unique names in SQS.
+When using custom queue names, it is important to ensure the names are unique between projects and environments. One easy way to accomplish this is by using the `SQS_SUFFIX` environment variable in each environment. This guarantees that custom queues have a unique name in SQS.
 :::
 
 ### Disabling The Queue


### PR DESCRIPTION
This pull request improves "Duplicate Queue Names" section, by mentioning `SQS_SUFFIX` environment variable as a easy way to avoid collisions.