### PR TITLE
Update deployments.md

### DIFF
--- a/src/projects/deployments.md
+++ b/src/projects/deployments.md
@@ -169,7 +169,7 @@ When using CI platforms, you may not have access to the environment files as the
 When using Vite and running `npm run build`, Vite will always use the `.env.production` file if it is present, even if you are deploying a different environment. If you maintain multiple environment files in your deployment environment, you should set the Vite build mode explicitly:
 
 ```shell
-npm run build -- --mode staging
+npm run build --mode staging
 ```
 :::
 


### PR DESCRIPTION
Fix the command example for different vite build mode as stated in the vitejs docs:

<img width="715" alt="CleanShot 2023-08-07 at 07 39 22@2x" src="https://github.com/andresayej/vapor-docs/assets/38343686/6c06e2b3-d11e-4830-bf7c-67fee2dfaccc">

https://vitejs.dev/guide/env-and-mode.html#modes