### PR TITLE
Fix all icons on nested routes

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -14,23 +14,23 @@ export default defineConfigWithTheme<ThemeConfig>({
         ['link', {
             rel: 'apple-touch-icon',
             sizes: '180x180',
-            href: 'apple-touch-icon.png',
+            href: '/apple-touch-icon.png',
         }],
         ['link', {
             rel: 'icon',
             sizes: '16x16',
             type: 'image/png',
-            href: 'favicon-16px.png',
+            href: '/favicon-16px.png',
         }],
         ['link', {
             rel: 'icon',
             sizes: '32x32',
             type: 'image/png',
-            href: 'favicon-32px.png',
+            href: '/favicon-32px.png',
         }],
         ['link', {
             rel: 'mask-icon',
-            href: 'safari-pinned-tab.svg',
+            href: '/safari-pinned-tab.svg',
         }],
         ['meta', {
             name: 'msapplication-TileColor',
@@ -38,11 +38,11 @@ export default defineConfigWithTheme<ThemeConfig>({
         }],
         ['meta', {
             name: 'msapplication-TileImage',
-            content: 'mstile-150x150.png',
+            content: '/mstile-150x150.png',
         }],
         ['meta', {
             property: 'og:image',
-            content: 'social-share.png',
+            content: '/social-share.png',
         }],
         ['meta', {
             property: 'twitter:card',
@@ -54,7 +54,7 @@ export default defineConfigWithTheme<ThemeConfig>({
         }],
         ['meta', {
             property: 'twitter:image',
-            content: 'social-share.png',
+            content: '/social-share.png',
         }],
     ],
 


### PR DESCRIPTION
I noticed favicons weren't working correctly on nested routes like '/projects/troubleshooting.html'

![image](https://github.com/Willem-Jaap/vapor-docs/assets/67187467/c129beaf-ff88-40be-bff6-4ecedc6d7613)

Because there is no `/` prefix in the vitepress config href's it tries to fetch from the current directory.

The [vitepress docs](https://vitepress.dev/reference/site-config#example-adding-a-favicon) prefix with a slash too.