### PR TITLE
Add Vapor's limit of 2,000 chars for env variables

### DIFF
--- a/src/projects/environments.md
+++ b/src/projects/environments.md
@@ -131,7 +131,7 @@ After updating an environment's variables, the new variables will not be utilize
 
 :::warning Environment Variable Limits
 
-Due to AWS Lambda limitations, your environment variables may only be 4kb in total. You should use encrypted environment files in place of or in addition to environment variables if you exceed this limit.
+Due to AWS Lambda limitations, your environment variables may only be 4kb in total. Vapor ensures this by limiting them to a total of 2,000 characters. You should use encrypted environment files in place of or in addition to environment variables if you exceed this limit.
 :::
 
 ### Reserved Environment Variables

--- a/src/projects/environments.md
+++ b/src/projects/environments.md
@@ -131,7 +131,7 @@ After updating an environment's variables, the new variables will not be utilize
 
 :::warning Environment Variable Limits
 
-Due to AWS Lambda limitations, your environment variables may only be 4kb in total. Vapor ensures this by limiting them to a total of 2,000 characters. You should use encrypted environment files in place of or in addition to environment variables if you exceed this limit.
+Due to AWS Lambda limitations, your environment variables may only be 4kb in total. To accomodate Vapor's own injection of environment variables, users are limited to 2,000 characters of environment variables. You should use encrypted environment files in place of or in addition to environment variables if you exceed this limit.
 :::
 
 ### Reserved Environment Variables

--- a/src/projects/environments.md
+++ b/src/projects/environments.md
@@ -131,7 +131,7 @@ After updating an environment's variables, the new variables will not be utilize
 
 :::warning Environment Variable Limits
 
-Due to AWS Lambda limitations, your environment variables may only be 4kb in total. To accomodate Vapor's own injection of environment variables, users are limited to 2,000 characters of environment variables. You should use encrypted environment files in place of or in addition to environment variables if you exceed this limit.
+Due to AWS Lambda limitations, your environment variables may only be 4kb in total. To accommodate Vapor's own injection of environment variables, users are limited to 2,000 characters of environment variables. You should use encrypted environment files in place of or in addition to environment variables if you exceed this limit.
 :::
 
 ### Reserved Environment Variables


### PR DESCRIPTION
The documentation currently states environment variables are limited to 4kb. This however is not fully true as Vapor itself limits them to 2,000 chars when running `env:push`. 2,000 chars is closer to 2kb which is confusing. This PR adds clarification that Vapor is restricting to 2,000 chars to ensure they don't go above 4kb.